### PR TITLE
Redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Redirect the user to a different route instead of dispatching an action. This is
 redirects is desired, such as an old route being deprecated.
 
 ```JavaScript
-import createRouter from '@density/conduit';
+import createRouter, { redirect } from '@density/conduit';
 import store from './store';
 
 const router = createRouter(store);

--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ Pass a rails-style path and an object containing values for any route parameters
 
 Match a literal `path` (no colons) against all routes and dispatch the matching action, passing in route parameters. `path` defaults to `window.location.hash` with leading and trailing slashes stripped out.
 
+## `redirect`
+
+Redirect the user to a different route instead of dispatching an action. This is useful anytime a
+redirects is desired, such as an old route being deprecated.
+
+```JavaScript
+import createRouter from '@density/conduit';
+import store from './store';
+
+const router = createRouter(store);
+router.addRoute('foo/bar', redirect('hello/world'));
+router.addRoute('hello/world', () => ({type: "NAVIGATE_TO_HELLO_WORLD"}) );
+```
 
 ## Development
 

--- a/index.js
+++ b/index.js
@@ -25,12 +25,21 @@ export function handle(routes, store, path) {
   path = path || window.location.hash.slice(1).replace(/(^\/|\/$)/, '');
   var route = checkPath(routes, path);
   if (route) {
-    var params = route.regexp.exec(path).slice(1);
-    store.dispatch(route.action.apply(route, params));
+    const params = route.regexp.exec(path).slice(1);
+    const action = route.action.apply(route, params);
+    if (action) {
+      store.dispatch(action);
+    }
     return true;
   } else {
     console.warn('Route to ' + path + ' not found!');
     return false
+  }
+}
+
+export function redirect(url) {
+  return () => {
+    window.location.href = url;
   }
 }
 


### PR DESCRIPTION
Add a helper that can be used for redirecting to a different route.

The dashboard uses a pattern similar to this already, though I'm not completely sold on it since this change effectively adds the ability for an action creator that returns nothing (like the `redirect` action creator) to be a side-effect only action creator and I'm not sure if that's starting down a path of making this project too all-encompassing.

```
import createRouter, { redirect } from '@density/conduit';

const router = createRouter(store);
router.addRoute('foo/bar', redirect('hello/world'));
router.addRoute('hello/world', () => ({type: "NAVIGATE_TO_HELLO_WORLD"}) );
```